### PR TITLE
Fix Docker publishing race and Zou startup failure

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -18,11 +18,11 @@ jobs:
         with:
           token: ${{ secrets.PAT_TOKEN }}
 
-      - name: Fetch latest versions from GitHub
+      - name: Fetch latest published versions
         id: fetch
         run: |
-          KITSU_VERSION=$(curl -s https://api.github.com/repos/cgwire/kitsu/releases/latest | jq -r '.tag_name' | sed 's/^v//')
-          ZOU_VERSION=$(curl -s https://api.github.com/repos/cgwire/zou/tags | jq -r '.[0].name' | sed 's/^v//')
+          KITSU_VERSION=$(curl -fsS https://api.github.com/repos/cgwire/kitsu/releases/latest | jq -er '.tag_name' | sed 's/^v//')
+          ZOU_VERSION=$(curl -fsS https://pypi.org/pypi/zou/json | jq -er '.info.version')
 
           for v in "$KITSU_VERSION" "$ZOU_VERSION"; do
             if ! echo "$v" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ docker build --build-arg KITSU_VERSION=1.0.17 --build-arg ZOU_VERSION=1.0.18 -t 
 docker run --init -ti --rm -p 80:80 -p 1080:1080 --name cgwire cgwire/cgwire
 ```
 
+The container generates a temporary `SECRET_KEY` at startup. Pass
+`-e SECRET_KEY=<your-secret>` to keep sessions valid across container restarts.
+
 In order to enable data persistence, use a named volume for the database and thumbnails:
 
 ```bash

--- a/docker/start_zou.sh
+++ b/docker/start_zou.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -z "${SECRET_KEY:-}" ]]; then
+  export SECRET_KEY="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+  echo "Generated a temporary SECRET_KEY for this container."
+fi
+
 # create /var/run/postgresql
 . /usr/share/postgresql-common/init.d-functions
 create_socket_directory

--- a/justfile
+++ b/justfile
@@ -19,12 +19,12 @@ versions:
     @echo "INDEX_VERSION={{ INDEX_VERSION }}"
     @echo "Tag: {{ tag }}"
 
-# Fetch latest versions from GitHub and update versions.env
+# Fetch latest published versions and update versions.env
 update-versions:
     #!/usr/bin/env bash
     set -euo pipefail
-    KITSU_VERSION=$(curl -s https://api.github.com/repos/cgwire/kitsu/releases/latest | jq -r '.tag_name' | sed 's/^v//')
-    ZOU_VERSION=$(curl -s https://api.github.com/repos/cgwire/zou/tags | jq -r '.[0].name' | sed 's/^v//')
+    KITSU_VERSION=$(curl -fsS https://api.github.com/repos/cgwire/kitsu/releases/latest | jq -er '.tag_name' | sed 's/^v//')
+    ZOU_VERSION=$(curl -fsS https://pypi.org/pypi/zou/json | jq -er '.info.version')
     echo "Latest Kitsu: ${KITSU_VERSION}"
     echo "Latest Zou:   ${ZOU_VERSION}"
     sed -i'' -e "s/^KITSU_VERSION=.*/KITSU_VERSION=${KITSU_VERSION}/" versions.env


### PR DESCRIPTION
## What

### Docker Build Failure
Fixes [run 29901553290](https://github.com/cgwire/kitsu-docker/actions/runs/29901553290) by selecting a Zou version published on PyPI, preventing the build from requesting a version that is only tagged on GitHub.

### Docker Runtime Failure
Fixes [job 87938237164](https://github.com/cgwire/kitsu-docker/actions/runs/29596159903/job/87938237164) by generating a secure temporary SECRET_KEY when none is provided, allowing Zou’s Gunicorn workers to start successfully.
Explicitly configured secrets remain unchanged.

## Why

The Docker workflow could select a Zou Git tag before that version was available on PyPI, causing pip install to fail and preventing image publication.

Recent Zou versions also reject the insecure default SECRET_KEY in production. This caused Gunicorn to fail at startup while nginx returned 502 Bad Gateway, making the post-publication tests fail.